### PR TITLE
Publish package

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,23 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://npm.pkg.github.com'
+          # Defaults to the user or organization that owns the workflow file
+          scope: '@xibosignage'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "xibo-layout-renderer",
+  "name": "@xibosignage/xibo-layout-renderer",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "xibo-layout-renderer",
+      "name": "@xibosignage/xibo-layout-renderer",
       "version": "1.0.0",
       "license": "LGPL-3.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xibo-layout-renderer",
+  "name": "@xibosignage/xibo-layout-renderer",
   "version": "1.0.0",
   "description": "Xibo layout renderer is a shared library that performs rendering of given layout from sources (e.g. CMS Preview, Linux Player, etc.)",
   "main": "dist/xibo-layout-renderer.cjs.js",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/xibosignage/xibo-layout-renderer.git"
+    "url": "https://github.com/xibosignage/xibo-layout-renderer.git"
   },
   "files": [
     "xibo-layout-renderer.esm.js",


### PR DESCRIPTION
Publishing the package to github packages requires us to change the package name so that it is scoped to our organisation. This is then configured to publish on release.