### PR TITLE
Upload to npm registry instead of GitHub packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,14 +10,12 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          # Defaults to the user or organization that owns the workflow file
           scope: '@xibosignage'
       - run: npm ci
-      - run: npm publish
+      - run: npm run build
+      - run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-Xibo Layout Renderer
+# Xibo Layout Renderer
+This is a npm module for rendering Xibo layouts to a browser window.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xibosignage/xibo-layout-renderer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Xibo layout renderer is a shared library that performs rendering of given layout from sources (e.g. CMS Preview, Linux Player, etc.)",
   "main": "dist/xibo-layout-renderer.cjs.js",
   "module": "dist/xibo-layout-renderer.esm.js",
@@ -10,10 +10,7 @@
     "build": "rimraf dist && rollup --config rollup.config.prod.ts --configPlugin @rollup/plugin-typescript",
     "dev": "rimraf dist && rollup --config rollup.config.dev.ts -w --configPlugin @rollup/plugin-typescript"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/xibosignage/xibo-layout-renderer.git"
-  },
+  "repository": "git+https://github.com/xibosignage/xibo-layout-renderer.git",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
We're switching to npm public register because it is not possible to authenticate to GitHub package registry using fine grained PAT