### PR TITLE
Compatibility with CMS_ALIAS

### DIFF
--- a/src/Modules/Layout/Layout.ts
+++ b/src/Modules/Layout/Layout.ts
@@ -91,7 +91,7 @@ export function initRenderingDOM(targetContainer: Element | null) {
 }
 
 export async function getXlf(layoutOptions: OptionsType) {
-    let apiHost = window.location.origin;
+    let apiHost = window.location.href.split("/layout")[0];
 
     let xlfUrl = apiHost + layoutOptions.xlfUrl;
     let fetchOptions: RequestInit = {};


### PR DESCRIPTION
This patch fixes layout preview when CMS_ALIAS is defined in [xibo-docker](https://github.com/xibosignage/xibo-docker)