### PR TITLE
Playback optimization: gapless transitions, accurate media timer, schedule-removal recovery

### DIFF
--- a/src/Modules/Layout/Layout.ts
+++ b/src/Modules/Layout/Layout.ts
@@ -328,21 +328,6 @@ export default class Layout implements ILayout {
                 isInterrupt: layout.isInterrupt(),
             });
 
-            if ($layout !== null) {
-                $layout.style.setProperty('visibility', 'hidden');
-                $layout.style.setProperty('opacity', '0');
-                $layout.style.setProperty('z-index', '-99');
-                console.debug('??? XLR.debug >> Layout.on("end") - Hiding currentLayout...');
-
-                // setTimeout(() => {
-                    console.debug('??? XLR.debug >> Layout.on("end") > setTimeout - Removing currentLayout', {
-                        layoutId: layout.layoutId,
-                    });
-
-                    $layout.parentElement?.removeChild($layout);
-                // }, 250);
-            }
-
             // Check if stats are enabled for the layout
             if (layout.enableStat) {
                 this.statsBC.postMessage({
@@ -359,11 +344,43 @@ export default class Layout implements ILayout {
             await layout.xlr.emitSync('layoutEnd', layout);
 
             if (this.xlr.config.platform !== ConsumerPlatform.CMS && layout.inLoop) {
-                // Transition next layout to current layout and prepare next layout if exist
+                // Gapless playback: nextLayout is already constructed and in the DOM
+                // (hidden). Show it first, then remove A — both DOM mutations are
+                // synchronous and the browser batches them into a single paint so
+                // there is never a blank frame between the two layouts.
+                // Safety: layout.done was set to true above, so for a single-layout
+                // loop where nextLayout === layout (same object), !immediateNext.done
+                // is false and the fast-path is correctly skipped.
+                const immediateNext = this.xlr.nextLayout;
+                const canRunImmediately =
+                    immediateNext != null &&
+                    !immediateNext.done &&
+                    immediateNext.layoutNode != null &&
+                    immediateNext.xlfString !== '';
+
+                if (canRunImmediately) {
+                    this.xlr.currentLayout = immediateNext;
+                    this.xlr.currentLayoutId = immediateNext.layoutId;
+                    // Update index immediately so any concurrent reader (gotoNextLayout,
+                    // updateLoop's parseLayouts) sees B's position before prepareLayouts()
+                    // has a chance to set it. nextLayout still points to B briefly until
+                    // prepareLayouts() replaces it with C — see updateLoop guard below.
+                    this.xlr.currentLayoutIndex = immediateNext.index;
+                    this.xlr.playLayouts(this.xlr);
+                }
+                // Remove A after B is shown (canRunImmediately) or immediately
+                // (no prepped next) — both paths end here so no blank frame in either case.
+                if ($layout !== null) {
+                    $layout.parentElement?.removeChild($layout);
+                }
+
                 this.xlr.prepareLayouts().then(async (_xlr) => {
                     console.log('>>>> XLR.debug XLR::Layout.on("end")', {_xlr, layout});
 
-                    this.xlr.playLayouts(_xlr);
+                    // Skip if fast-path already started the layout — it's already RUNNING.
+                    if (!canRunImmediately) {
+                        this.xlr.playLayouts(_xlr);
+                    }
 
                     if (layout.isInterrupt() && _xlr.currentLayout && !_xlr.currentLayout.isInterrupt()) {
                         // Start back overlay layouts when previous layout is interrupt
@@ -371,6 +388,11 @@ export default class Layout implements ILayout {
                         await _xlr.overlayLayoutManager.resumeOverlays();
                     }
                 });
+            } else {
+                // CMS platform or layout not in loop — remove A immediately.
+                if ($layout !== null) {
+                    $layout.parentElement?.removeChild($layout);
+                }
             }
         });
 

--- a/src/Modules/Media/Media.ts
+++ b/src/Modules/Media/Media.ts
@@ -284,9 +284,17 @@ export class Media implements IMedia {
             mediaDuration: media.duration,
         });
 
+        // Capture wall-clock start time so elapsed is measured from real time rather
+        // than counted ticks. This prevents drift from JS event-loop scheduling jitter
+        // accumulating across media items.
+        const startTime = performance.now();
+
         this.mediaTimer = setInterval(() => {
-            this.mediaTimeCount++;
-            const elapsedTimeMs = (this.mediaTimeCount * 1000);
+            const elapsedTimeMs = performance.now() - startTime;
+            // Keep mediaTimeCount in whole seconds for backward-compat with any
+            // external code that reads it (e.g. stats).
+            this.mediaTimeCount = Math.floor(elapsedTimeMs / 1000);
+
             // prepare region's next media
             if (this.region.totalMediaObjects > 1 &&
               elapsedTimeMs >= preloadTimeBufferMs &&
@@ -296,7 +304,10 @@ export class Media implements IMedia {
                 this.region.prepareNextMedia();
             }
 
-            if (this.mediaTimeCount > media.duration) {
+            // Compare against wall-clock elapsed rather than tick count so the end
+            // fires at the true deadline. Reading media.duration each tick respects
+            // dynamic changes from extendWidgetDuration() / setWidgetDuration().
+            if (elapsedTimeMs >= media.duration * 1000) {
                 console.debug('??? XLR.debug >> Media::startMediaTimer: emit>end: on media ' + media.id + ' of Region ' + media.region.regionId);
 
                 console.debug('??? XLR.debug >> Media::startMediaTimer - Media::Emitter > End', {
@@ -316,7 +327,7 @@ export class Media implements IMedia {
                     }
                 }
             }
-        }, 1000);
+        }, 200);
 
         console.debug('startMediaTimer: Showing Media ' + media.id + ' for ' + media.duration + 's of Region ' + media.region.regionId);
     };

--- a/src/Types/XLR/XLR.types.ts
+++ b/src/Types/XLR/XLR.types.ts
@@ -77,8 +77,17 @@ export interface IXlr {
 
     getLayoutById(layoutId: number, layoutIndex?: number): ILayout | undefined;
 
+    /**
+     * Advance immediately to the next layout in the loop. The loop always
+     * pre-prepares nextLayout, so the transition is gapless — no XLF fetch needed.
+     */
     gotoNextLayout(): void;
 
+    /**
+     * Jump immediately to the previous layout in the loop. Discards the
+     * pre-prepared nextLayout, prepares the target, then ends the current layout
+     * early — on('end') performs the gapless transition.
+     */
     gotoPrevLayout(): void;
 
     /**

--- a/src/xibo-layout-renderer.ts
+++ b/src/xibo-layout-renderer.ts
@@ -381,25 +381,61 @@ export default function XiboLayoutRenderer(
                     this.currentLayout.removeLayout();
                 }
 
-                if (this.nextLayout &&
-                    this.isLayoutInDOM(this.nextLayout.containerName, this.nextLayout.index)
-                ) {
-                    this.nextLayout.discardLayout(LayoutPlaybackType.NEXT);
-                }
+                // If the pre-prepared nextLayout is still valid in the new schedule
+                // and matches what parseLayouts selected as the new current, reuse it
+                // directly — no async XLF fetch needed, no blank-screen window.
+                const nextIsReusable =
+                    this.nextLayout != null &&
+                    !this.nextLayout.done &&
+                    this.nextLayout.layoutNode != null &&
+                    this.nextLayout.xlfString !== '' &&
+                    playback.currentLayout != null &&
+                    isLayoutValid(this.inputLayouts, this.nextLayout.layoutId) &&
+                    this.nextLayout.layoutId === playback.currentLayout.layoutId;
 
-                if (playback.currentLayout) {
-                    await prepareNewCurrentLayout();
-                }
+                if (nextIsReusable && this.nextLayout) {
+                    const reuseLayout = this.nextLayout;
+                    this.nextLayout = undefined;
+                    this.currentLayout = reuseLayout;
+                    this.currentLayoutId = reuseLayout.layoutId;
+                    this.currentLayoutIndex = playback.currentLayoutIndex;
 
-                if (playback.nextLayout) {
-                    this.nextLayout = await this.prepareForSsp(await this.prepareLayoutXlf(playback.nextLayout));
+                    // Kick off prep for the slot after B in the background so
+                    // on('end') can fast-path gaplessly when B finishes.
+                    // .catch() keeps this fire-and-forget from becoming an unhandled
+                    // rejection on network/parse failure — nextLayout stays undefined
+                    // and on('end') falls back to prepareLayouts() for recovery.
+                    if (playback.nextLayout) {
+                        this.prepareLayoutXlf(playback.nextLayout)
+                            .then((next) => this.prepareForSsp(next))
+                            .then((next) => { this.nextLayout = next; })
+                            .catch(() => {});
+                    }
+                } else {
+                    if (this.nextLayout &&
+                        this.isLayoutInDOM(this.nextLayout.containerName, this.nextLayout.index)
+                    ) {
+                        this.nextLayout.discardLayout(LayoutPlaybackType.NEXT);
+                    }
+
+                    if (playback.currentLayout) {
+                        await prepareNewCurrentLayout();
+                    }
+
+                    if (playback.nextLayout) {
+                        this.nextLayout = await this.prepareForSsp(await this.prepareLayoutXlf(playback.nextLayout));
+                    }
                 }
             }
 
             await this.playSchedules(this);
         } else {
-            // Remove next layout if it is in the DOM
+            // Remove next layout if it is in the DOM.
+            // Guard: never discard nextLayout when it IS currentLayout — this happens
+            // briefly during the gapless fast-path in on('end') while prepareLayouts()
+            // is running asynchronously. Discarding it would remove the playing layout.
             if (this.nextLayout &&
+                this.nextLayout !== this.currentLayout &&
                 this.isLayoutInDOM(this.nextLayout.containerName, this.nextLayout.index)
             ) {
                 this.nextLayout.discardLayout(LayoutPlaybackType.NEXT);
@@ -940,21 +976,22 @@ export default function XiboLayoutRenderer(
             console.debug('XLR::gotoPrevLayout', { previousLayoutIndex: _assumedPrevIndex });
 
             if (Boolean(this.inputLayouts[_assumedPrevIndex])) {
-                // Prevent the natural layout-end handler from also calling
-                // prepareLayouts() when finishAllRegions() causes the layout
-                // 'end' event to fire.
-                if (this.currentLayout) {
-                    this.currentLayout.inLoop = false;
+                // Discard the existing nextLayout before replacing it with the target.
+                if (this.nextLayout &&
+                    this.isLayoutInDOM(this.nextLayout.containerName, this.nextLayout.index)
+                ) {
+                    this.nextLayout.discardLayout(LayoutPlaybackType.NEXT);
                 }
 
-                await this.currentLayout?.finishAllRegions();
-
-                // and set the previous layout as current layout
+                // Pre-prepare the target layout as nextLayout while A is still playing.
+                // on('end') will fast-path to it gaplessly — no inLoop=false needed.
+                let targetLayout = this.getLayout(this.inputLayouts[_assumedPrevIndex]);
+                targetLayout = setLayoutIndex(targetLayout, _assumedPrevIndex);
+                this.nextLayout = await this.prepareForSsp(await this.prepareLayoutXlf(targetLayout));
                 this.currentLayoutIndex = _assumedPrevIndex;
 
-                this.prepareLayouts().then(async (xlr) => {
-                    await this.playSchedules(xlr);
-                });
+                await this.currentLayout?.finishAllRegions();
+                // on('end') handles the gapless transition and prepareLayouts for the new next.
             }
         } finally {
             isNavigatingLayout = false;
@@ -974,15 +1011,12 @@ export default function XiboLayoutRenderer(
 
             console.debug('XLR::gotoNextLayout', { nextLayoutIndex: nextIndex });
 
-            if (this.currentLayout) {
-                this.currentLayout.inLoop = false;
-            }
-
-            await this.currentLayout?.finishAllRegions();
+            // The normal loop always pre-prepares the layout at currentLayoutIndex+1 as
+            // nextLayout — that is exactly the target here. No discard or re-prepare
+            // needed: just end A early and let on('end') fast-path to the already-ready
+            // nextLayout gaplessly, then kick off prepareLayouts() for the layout after B.
             this.currentLayoutIndex = nextIndex;
-            this.prepareLayouts().then(async (xlr) => {
-                await this.playSchedules(xlr);
-            });
+            await this.currentLayout?.finishAllRegions();
         } finally {
             isNavigatingLayout = false;
         }
@@ -1069,17 +1103,22 @@ export default function XiboLayoutRenderer(
 
             console.debug('XLR::gotoLayoutByCode', { layoutCode, targetIndex });
 
-            // Prevent the natural layout-end handler from racing with our own
-            // prepareLayouts() call (same pattern as gotoPrevLayout/gotoNextLayout).
-            if (this.currentLayout) {
-                this.currentLayout.inLoop = false;
+            // Discard the existing nextLayout before replacing it with the target.
+            if (this.nextLayout &&
+                this.isLayoutInDOM(this.nextLayout.containerName, this.nextLayout.index)
+            ) {
+                this.nextLayout.discardLayout(LayoutPlaybackType.NEXT);
             }
 
-            await this.currentLayout?.finishAllRegions();
+            // Pre-prepare the target layout as nextLayout while A is still playing.
+            // on('end') will fast-path to it gaplessly — no inLoop=false needed.
+            let targetLayout = this.getLayout(this.inputLayouts[targetIndex]);
+            targetLayout = setLayoutIndex(targetLayout, targetIndex);
+            this.nextLayout = await this.prepareForSsp(await this.prepareLayoutXlf(targetLayout));
             this.currentLayoutIndex = targetIndex;
-            this.prepareLayouts().then(async (xlr) => {
-                await this.playSchedules(xlr);
-            });
+
+            await this.currentLayout?.finishAllRegions();
+            // on('end') handles the gapless transition and prepareLayouts for the new next.
         } finally {
             isNavigatingLayout = false;
         }


### PR DESCRIPTION
relates to xibosignage/xibo-layout-renderer#116

- Gapless layout transition: show next layout before removing current - eliminate blank frame between layouts
- Guard against discarding the playing layout during async schedule updates
- Reuse already-prepared next layout when current is removed from schedule - no blank window on recovery
- Navigate previous / by code: prepare target layout in the background before showing for gapless transition
- Navigate next: skip redundant layout preparation - target is already prep-prepared by the normal loop
- Media timer now fires ath the true deadline instead of up to one second late
- Added API docs to navigation methods