### PR TITLE
Fix Electron webpage widget rendering

### DIFF
--- a/src/Modules/Generators/Generators.ts
+++ b/src/Modules/Generators/Generators.ts
@@ -409,7 +409,7 @@ export function prepareIframe(media: IMedia) {
     iframe.style.cssText = `border: 0;`;
 
 
-    if ((media.render === 'html' || media.render === 'webpage') && media.url !== null) {
+    if ((media.render === 'html' || media.mediaType === 'webpage') && media.url !== null) {
         iframe.src = media.url;
     } else {
         iframe.src = `${media.url}&width=${media.divWidth}&height=${media.divHeight}`;

--- a/src/Modules/Media/Media.ts
+++ b/src/Modules/Media/Media.ts
@@ -401,14 +401,11 @@ export class Media implements IMedia {
             fileId: this.fileId,
             scaleFactor: this.region.layout.scaleFactor,
             uri: this.uri,
+            mediaType: this.mediaType,
             isGlobalContent: this.mediaType === 'global',
             isImageOrVideo: this.mediaType === 'image' || this.mediaType === 'video',
             render: this.render,
         };
-
-        if (this.mediaType === 'image' || this.mediaType === 'video') {
-            resourceUrlParams.mediaType = this.mediaType;
-        }
 
         // SSP widget: URL is not known until the consumer resolves an ad at play-time.
         // Skip all URL composition and leave url as null.


### PR DESCRIPTION
## Summary

Fix Electron rendering for Website widgets (`type="webpage"`) by carrying the widget `mediaType` into Electron resource URL resolution and using `mediaType === 'webpage'` when preparing iframe sources.
This fix also addresses https://github.com/xibosignage/electron-player/issues/149 where the website wouldn't redner.

## Problem

In the Electron player, Website widgets could render as blank even though:

- the layout/XLF contained the correct widget URL
- the widget wrapper HTML was generated correctly
- the same page rendered in CMS/browser preview

The root issue was that webpage widgets arrive with:

- `type="webpage"`
- `render="native"`

but the Electron/XLR code path did not consistently treat them as webpage widgets.

## Root Cause

There were two related issues:

1. `Media.ts` only added `mediaType` to `resourceUrlParams` for images and videos.
   That meant Electron URL composition could not match the webpage widget branch:

   ```ts
   params.mediaType === 'webpage'
   ```

   so the local wrapper URL (`layout_<layout>_region_<region>_media_<media>.html`) was not selected.

2. `prepareIframe()` checked:

   ```ts
   media.render === 'webpage'
   ```

   but webpage widgets in this case use `render="native"` and `mediaType="webpage"`.

   As a result, iframe creation fell through to the wrong branch.

## Changes

### `src/Modules/Media/Media.ts`

Always pass:

```ts
mediaType: this.mediaType
```

into `resourceUrlParams`.

This allows Electron resource URL composition to correctly identify webpage widgets and resolve them to the local wrapper HTML.

### `src/Modules/Generators/Generators.ts`

Change iframe preparation to check:

```ts
media.mediaType === 'webpage'
```

instead of:

```ts
media.render === 'webpage'
```

This ensures webpage widgets use their resolved URL directly when creating the iframe.

## Result

Before this change, Electron could fall back to an incorrect local `file:///.../index.html` iframe path or render a blank Website widget.

After this change:

- the local wrapper HTML is selected correctly for webpage widgets
- the nested iframe resolves to the actual remote webpage URL
- Website widgets render correctly in the Electron player

## Reproduction

1. Schedule a Layout with a website widget.
2. Ensure the widget is represented in XLF as `type="webpage"` and `render="native"`.
3. Run the Electron player.
4. Observe that the widget area is blank before this fix.

With this fix applied, the Website widget renders correctly.
